### PR TITLE
Deleted bind call for handleClick

### DIFF
--- a/frontend/src/components/videoitem.js
+++ b/frontend/src/components/videoitem.js
@@ -3,7 +3,6 @@ import React, {Component} from 'react'
 export default class VideoItem extends Component {
 constructor(props){
     super(props);
-    this.handleClick = this.handleClick.bind(this);
 }
 
 componentDidMount(){


### PR DESCRIPTION
Fat arrow functions do not need an explicit binding.